### PR TITLE
Allow controlling the paper size (support A4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ You can also "print" to a PDF.
 A lot of features can be customized by changing constants at the top of `label-generator.py`.
 For example, sets can be excluded one-by-one or in groups by type or sets can be renamed.
 
-The labels are designed for US Letter paper but this can be customized.
+The labels are designed for US Letter paper but this can be customized:
+
+    python label-generator.py --paper-size=a4   # Use A4 paper size
+    python label-generator.py --help   # Show all options
+
 
 You can change how the labels are actually displayed and rendered by customizing `templates/labels.svg`.
 If you change the fonts, you may also need to resize things to fit.


### PR DESCRIPTION
Allow generating labels for A4 paper with a command line option (Letter is the default):

    python label-generator.py --paper-size=a4

Fixes https://github.com/davidfischer/mtg-printable-set-label-generator/issues/2

I didn't incorporate the SVG -> PDF parts of #2 but I'll do that in a separate PR.