### PR TITLE
Handle set icons differently

### DIFF
--- a/mtglabels/generator.py
+++ b/mtglabels/generator.py
@@ -1,4 +1,5 @@
 import argparse
+import base64
 import logging
 import os
 import subprocess
@@ -242,12 +243,18 @@ class LabelGenerator:
 
         for exp in set_data:
             name = RENAME_SETS.get(exp["name"], exp["name"])
+            icon_resp = requests.get(exp["icon_svg_uri"])
+            icon_b64 = None
+            if icon_resp.ok:
+                icon_b64 = base64.b64encode(icon_resp.content).decode('utf-8')
+
             labels.append(
                 {
                     "name": name,
                     "code": exp["code"],
                     "date": datetime.strptime(exp["released_at"], "%Y-%m-%d").date(),
                     "icon_url": exp["icon_svg_uri"],
+                    "icon_b64": icon_b64,
                     "x": x,
                     "y": y,
                 }

--- a/mtglabels/templates/labels.svg
+++ b/mtglabels/templates/labels.svg
@@ -10,7 +10,9 @@
             <!-- {{ label.name }} -->
             <text x="{{ label.x + 30 }}" y="{{ label.y + 30 }}" font-size="32" dominant-baseline="hanging" style="font-weight: bold; font-family: 'EB Garamond', 'Times New Roman', serif">{{ label.name | escape }}</text>
             <text x="{{ label.x + 30 }}" y="{{ label.y + 70 }}" font-size="25" dominant-baseline="hanging" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif">{{ label.code | upper | escape }} - {{ label.date.strftime('%B %Y') }}</text>
-            <image x="{{ label.x + 490 }}" y="{{ label.y + 20 }}" width="70" height="70" href="{{ label.icon_url }}" />
+            {% if label.icon_b64 %}
+                <image x="{{ label.x + 490 }}" y="{{ label.y + 20 }}" width="70" height="70" xlink:href="data:image/svg+xml;base64,{{ label.icon_b64 }}" />
+            {% endif %}
         </g>
     {% endfor %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Jinja2==3.1.2
 requests==2.22.0
-CairoSVG==2.5.2
+CairoSVG==2.7.1
 
 # For development only
 black==19.10b0


### PR DESCRIPTION
Cairo, the part of this app that converts SVGs to PDFs changed how it handles remote images (images starting with https://...). To work around this, we will download the set icons and embed them as base64 which should hopefully resolve these issues.