### PR TITLE
Fix problems when running on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ dmypy.json
 cython_debug/
 
 output/
+.idea


### PR DESCRIPTION
Hi, there was a problem running the generator on a Windows machine, which should be fixed (without affecting other platforms)

In this context, I fixed a couple minor issues:

- DEFAULT_PAPER_SIZE and DEFAULT_OUTPUT_DIR were sometimes scoped differently (with or without class LabelGenerator, e.g.
  - `self.paper_size = paper_size or DEFAULT_PAPER_SIZE` vs. `default=LabelGenerator.DEFAULT_PAPER_SIZE`
- moved the variables that are global and have nothing to do with the class outside LabelGenerator.